### PR TITLE
Move to Dockerhub.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
-REGISTRY    ?= quay.io/flippa
-PROJECT     ?= curator
+REPOSITORY   = flippa/curator
 TAG         ?= v1
-IMAGE       = $(REGISTRY)/$(PROJECT):$(TAG)
+IMAGE        = $(REPOSITORY):$(TAG)
+LATEST       = $(REPOSITORY):latest
 
-.PHONY: image
 image: Dockerfile
 	docker build --rm -t $(IMAGE) .
+	docker tag -f $(IMAGE) $(LATEST)
 
 .PHONY: push
 push:
 	docker push $(IMAGE)
+	docker push $(LATEST)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ docker-curator
 Docker image for [elastic curator](https://github.com/elastic/curator/).
 
 ```shell
-$ docker run --rm quay.io/flippa/curator:v1 --version
+$ docker run --rm flippa/curator:v1 --version
 curator, version 3.4.0
 ```


### PR DESCRIPTION
We're moving our public Docker images to Dockerhub.